### PR TITLE
Fix nginx ports

### DIFF
--- a/tests/compose/docker-compose.yml
+++ b/tests/compose/docker-compose.yml
@@ -6,9 +6,9 @@ services:
     volumes:
       - "./nginx/reverse-https-proxy.conf:/etc/nginx/nginx.conf"
       - "./nginx/ssl:/etc/ssl"
-    expose:
-      - "3010"
-      - "3000"
+    ports:
+      - "3010:3010"
+      - "3000:3000"
 
   bitcoind:
     restart: unless-stopped


### PR DESCRIPTION
one reason the tests weren't passing:

I thought expose was shorthand for ports but that was wrong.

expose section allows us to expose specific ports from our container only to other services on the same network. ports are open not only for other services on the same network but also to the host.

