### PR TITLE
Add Cache Headers for static site

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -55,7 +55,11 @@ async fn handle_web_req(
             let file =
                 std::fs::read(Path::new(STATIC_DIR).join(directory_traversal_vulnerable_path))
                     .expect("can't open static file");
-            Ok(Response::new(Body::from(file)))
+            Ok(Response::builder()
+                .status(200)
+                .header("Cache-Control", "max-age=604800")
+                .body(Body::from(file))
+                .expect("valid response"))
         }
 
         (&Method::POST, "/pj") => {


### PR DESCRIPTION
Addresses https://github.com/chaincase-app/nolooking/issues/43

Add Cache-Control with a max age of one week.

This will improve (repeat) load performance a bit with caching. Will primarily help with access over Tor.

