### PR TITLE
Send PayJoin from LND

### DIFF
--- a/config_spec.toml
+++ b/config_spec.toml
@@ -43,3 +43,9 @@ name = "lnd_macaroon_path"
 type = "std::path::PathBuf"
 doc = "Path to LND macaroon with open channel permission"
 optional = false
+
+[[param]]
+name = "danger_accept_invalid_certs"
+type = "bool"
+doc = "If true, accept invalid TLS certificates. **Warning**: think very carefully before using this method. If invalid certificates are trusted, PayJoin is subject to man in the middle attacks and your bitcoins can be stolen. This introduces significant vulnerabilities, and should only be used for testing purposes."
+default = "false"

--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
 		</header>
 		<main class="center-axyz">
 			<form action="/schedule" method="post" enctype="application/x-www-form-urlencoded"
-			x-flex direction="column">
+			x-flex direction="column" id="batch-form">
 			<h3>Queue batches of lightning channels to open in a single transaction</h3>
 			<fieldset>
 					<legend>Lease Inbound Channel</legend>
@@ -88,6 +88,18 @@
 					<div id="lsp-response" class="invisible">
 						<!-- populated on POST /schedule response -->
 					</div>
+				</output>
+			</form>
+			<form action="/send" method="post" enctype="application/x-www-form-urlencoded"
+				x-flex direction="column" id="send-form">
+				<h3>Send PayJoin</h3>
+				
+				<label for="uri">Payment request (bitcoin: uri)</label>
+				<input type="text" name="uri" placeholder="bitcoin:..." required>
+
+				<button id="submit-send" type="submit" class="float-right colored-button" span="2">Send</button>
+				<output id="sent">
+					<p>this should be a real txid</p>
 				</output>
 			</form>
 		</main>
@@ -183,7 +195,7 @@
 				document.querySelector("#inboundCapacity").value = event.target.checked ? 1000000 : 0;
 			});
 
-			document.querySelector("form").addEventListener("submit", async (event) => {
+			document.querySelector("#batch-form").addEventListener("submit", async (event) => {
 				event.preventDefault();
 
 				// Disable hiddens if checkboxes are checked
@@ -229,6 +241,33 @@
 `
 							lspResponse.innerHTML = quoteTemplate;
 						}
+					})
+					.catch((err) => {
+						alert(err);
+					});
+				return false; // don't trigger form action attribute, we submitted through js
+			});
+
+			document.querySelector("#send-form").addEventListener("submit", async (event) => {
+				event.preventDefault();
+
+				let form = event.currentTarget;
+				let body = new FormData(form).get("uri");
+				console.debug(body);
+				let resource = form.action;
+				let options = {
+					method: form.method,
+					headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
+					body: body,
+				};
+
+				await fetch(resource, options)
+					.then(async (r) => {
+						console.debug(r);
+
+						let output = document.querySelector("#send-form output");
+						let txid = await r.text();
+						output.innerHTML = `Transaction sent: <a href="https://blockstream.info/tx/${txid}">${txid}</a>`;
 					})
 					.catch((err) => {
 						alert(err);

--- a/public/style.css
+++ b/public/style.css
@@ -53,6 +53,7 @@ p {
 
 main form {
     max-width: 800px;
+    min-width: 40vw;
     background: var(--black);
     border-radius: var(--radius);
     padding: 2rem;
@@ -62,8 +63,12 @@ form > * {
     padding-top: 2rem;
 }
 
-input {
+input[type=number] {
     text-align: right;
+}
+
+#sent {
+  display: none;
 }
 
 legend {

--- a/src/http.rs
+++ b/src/http.rs
@@ -204,7 +204,7 @@ async fn handle_send(
     let request: bip78::Uri<'_> =
         bip78::Uri::try_from(pj_uri).map_err(|_| PayJoinError::Internal("Bad PayJoin uri"))?;
 
-    let txid = scheduler.send_payjoin(request, true).await.map_err(PayJoinError::Scheduler)?;
+    let txid = scheduler.send_payjoin(request).await.map_err(PayJoinError::Scheduler)?;
     let mut response = Response::new(Body::from(txid.to_string()));
     response.headers_mut().insert(
         hyper::header::CONTENT_TYPE,

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::convert::TryFrom;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Arc;
@@ -69,6 +70,7 @@ async fn handle_web_req(
         (&Method::GET, "/notification") => handle_notification(notifications.clone()).await,
         (&Method::POST, "/schedule") => handle_schedule(scheduler, req).await,
         (&Method::GET, "/recommend") => handle_recommendations().await,
+        (&Method::POST, "/send") => handle_send(scheduler, req).await.map_err(HttpError::PayJoin),
         (&Method::GET, path) => serve_public_file(path).await,
         _ => handle_404().await,
     };
@@ -191,6 +193,26 @@ async fn handle_recommendations() -> Result<Response<Body>, HttpError> {
     Ok(response)
 }
 
+async fn handle_send(
+    scheduler: Scheduler,
+    req: Request<Body>,
+) -> Result<Response<Body>, PayJoinError> {
+    let bytes = hyper::body::to_bytes(req.into_body()).await?;
+    let pj_uri =
+        String::from_utf8(bytes.to_vec()).map_err(|_| PayJoinError::Internal("Bad PayJoin uri"))?;
+    log::debug!("PayJoin uri: {}", pj_uri);
+    let request: bip78::Uri<'_> =
+        bip78::Uri::try_from(pj_uri).map_err(|_| PayJoinError::Internal("Bad PayJoin uri"))?;
+
+    let txid = scheduler.send_payjoin(request, true).await.map_err(PayJoinError::Scheduler)?;
+    let mut response = Response::new(Body::from(txid.to_string()));
+    response.headers_mut().insert(
+        hyper::header::CONTENT_TYPE,
+        "text/plain".parse().map_err(|_| PayJoinError::Internal("Could not construct response"))?,
+    );
+    Ok(response)
+}
+
 pub(crate) struct Headers(hyper::HeaderMap);
 impl bip78::receiver::Headers for Headers {
     fn get_header(&self, key: &str) -> Option<&str> { self.0.get(key)?.to_str().ok() }
@@ -198,6 +220,7 @@ impl bip78::receiver::Headers for Headers {
 
 #[derive(Debug)]
 pub enum PayJoinError {
+    Internal(&'static str),
     Scheduler(SchedulerError),
     BadRequest(hyper::Error),
     Bip78Request(bip78::receiver::RequestError),
@@ -206,6 +229,7 @@ pub enum PayJoinError {
 impl std::fmt::Display for PayJoinError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Internal(msg) => write!(f, "Internal error: {}", msg),
             Self::Scheduler(err) => write!(f, "Scheduler error: {}", err),
             Self::Bip78Request(err) => write!(f, "Bip78 request error: {:?}", err), // TODO impl Display for RequestError @bip78
             Self::BadRequest(_) => write!(f, "Bad request"),

--- a/src/lnd.rs
+++ b/src/lnd.rs
@@ -4,12 +4,11 @@ use std::num::TryFromIntError;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use bitcoin::consensus::{Decodable, Encodable};
+use bitcoin::consensus::Decodable;
 use bitcoin::psbt::serialize::Serialize;
 use bitcoin::psbt::PartiallySignedTransaction;
 use bitcoin::{Address, Amount, Transaction};
 use ln_types::P2PAddress;
-use log::{info, warn};
 use tokio::sync::Mutex as AsyncMutex;
 use tonic_lnd::lnrpc::funding_transition_msg::Trigger;
 use tonic_lnd::lnrpc::{
@@ -126,9 +125,10 @@ impl LndClient {
                 Update::PsbtFund(ready) => {
                     let psbt = PartiallySignedTransaction::consensus_decode(&mut &*ready.psbt)
                         .map_err(LndError::Decode)?;
-                    info!(
+                    log::info!(
                         "PSBT received from LND for pending chan id {:?}: {:#?}",
-                        pending_chan_id, psbt
+                        pending_chan_id,
+                        psbt
                     );
                     assert_eq!(psbt.unsigned_tx.output.len(), 1);
 

--- a/src/lnd.rs
+++ b/src/lnd.rs
@@ -4,9 +4,10 @@ use std::num::TryFromIntError;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use bitcoin::consensus::Decodable;
+use bitcoin::consensus::{Decodable, Encodable};
+use bitcoin::psbt::serialize::Serialize;
 use bitcoin::psbt::PartiallySignedTransaction;
-use bitcoin::{Address, Amount};
+use bitcoin::{Address, Amount, Transaction};
 use ln_types::P2PAddress;
 use log::{info, warn};
 use tokio::sync::Mutex as AsyncMutex;
@@ -15,7 +16,7 @@ use tonic_lnd::lnrpc::{
     FundingPsbtVerify, FundingTransitionMsg, OpenChannelRequest, OpenStatusUpdate,
     WalletBalanceRequest,
 };
-use tonic_lnd::walletrpc::RequiredReserveRequest;
+use tonic_lnd::walletrpc::{RequiredReserveRequest, UtxoLease};
 
 use crate::scheduler::ChannelId;
 
@@ -173,6 +174,133 @@ impl LndClient {
         Ok(())
     }
 
+    /// Creates a fully populated PSBT with 1 output to the specified address of the
+    /// specified amount. Coin selection is performed automatically. After either verifying the
+    /// inputs, all input UTXOs are locked with an internal LND app ID.
+    ///
+    /// NOTE: If this method returns without an error, it is the caller's responsibility to either
+    /// spend the locked UTXOs (by finalizing and then publishing the transaction) or to
+    /// call [`release_utxos`] to unlock the locked UTXOs in case of an error on the caller's side.
+    pub async fn fund_original_psbt(
+        &self,
+        address: &bitcoin::Address,
+        amount: bitcoin::Amount,
+    ) -> Result<(PartiallySignedTransaction, Vec<UtxoLease>), LndError> {
+        use tonic_lnd::walletrpc::fund_psbt_request::{Fees, Template};
+        use tonic_lnd::walletrpc::{FundPsbtRequest, TxTemplate};
+
+        log::debug!("fund_original_psbt");
+        let client = &mut *self.0.lock().await;
+        let client = client.wallet();
+
+        let mut outputs = std::collections::HashMap::new();
+        outputs.insert(address.to_string(), amount.as_sat());
+        let tx_template = TxTemplate { outputs, ..Default::default() };
+        let template = Some(Template::Raw(tx_template));
+        let fees = Some(Fees::TargetConf(2));
+        let fund_psbt = FundPsbtRequest { template, fees, ..Default::default() };
+
+        let response = client.fund_psbt(fund_psbt).await?;
+        let stream = response.get_ref();
+        let raw_psbt = stream.funded_psbt.as_slice();
+        let funded_psbt =
+            PartiallySignedTransaction::consensus_decode(raw_psbt).map_err(LndError::BadPsbt)?;
+        log::debug!("funded Original PSBT");
+
+        Ok((funded_psbt, stream.locked_utxos.clone()))
+    }
+
+    /// Expects a partial transaction with all inputs and outputs fully declared and
+    /// tries to sign all unsigned inputs that have all required fields (UTXO information, BIP32
+    /// derivation information, witness or sig scripts) set. If no error is returned, the PSBT is
+    /// ready to be given to the next signer or to be finalized if lnd was the last signer.
+    ///
+    /// NOTE: This RPC only signs inputs (and only those it can sign), it does not perform any
+    /// other tasks (such as coin selection, UTXO locking or input/output/fee value validation,
+    /// PSBT finalization). Any input that is incomplete will be skipped.
+    pub async fn sign_psbt(
+        &self,
+        funded_psbt: PartiallySignedTransaction,
+    ) -> Result<PartiallySignedTransaction, LndError> {
+        log::debug!("sign psbt");
+
+        let client = &mut *self.0.lock().await;
+        let client = client.wallet();
+
+        let funded_psbt = bitcoin::consensus::serialize(&funded_psbt);
+        let req = tonic_lnd::walletrpc::SignPsbtRequest { funded_psbt, ..Default::default() };
+        let res = client.sign_psbt(req).await?;
+        let stream = res.get_ref();
+        let signed_psbt = stream.signed_psbt.as_slice();
+
+        let tx =
+            PartiallySignedTransaction::consensus_decode(signed_psbt).map_err(LndError::BadPsbt)?;
+        log::debug!("signed PSBT");
+
+        Ok(tx)
+    }
+
+    /// Expects a partial transaction with all inputs and outputs fully declared and tries to sign
+    /// all inputs that belong to the wallet. Lnd must be the last signer of the transaction. That means,
+    /// if there are any unsigned non-witness inputs or inputs without UTXO information attached or inputs
+    /// without witness data that do not belong to lnd's wallet, this method will fail. If no error is returned,
+    /// the PSBT is ready to be extracted and the final TX within to be broadcast.
+    ///
+    /// NOTE: This method does NOT publish the transaction once finalized. It is the caller's responsibility to
+    /// either publish the transaction on success or call [`release_utxos`] in case of an error in this method.
+    pub async fn finalize_psbt(
+        &self,
+        funded_psbt: PartiallySignedTransaction,
+    ) -> Result<Transaction, LndError> {
+        log::debug!("finalize_psbt");
+        let client = &mut *self.0.lock().await;
+        let client = client.wallet();
+
+        let funded_psbt = bitcoin::consensus::serialize(&funded_psbt);
+        let req = tonic_lnd::walletrpc::FinalizePsbtRequest { funded_psbt, ..Default::default() };
+        let res = client.finalize_psbt(req).await?;
+        let stream = res.get_ref();
+        let raw_final_tx = stream.raw_final_tx.as_slice();
+        let tx = Transaction::consensus_decode(raw_final_tx).map_err(LndError::BadPsbt)?;
+        Ok(tx)
+    }
+
+    pub async fn release_utxos(&self, utxos: Vec<UtxoLease>) -> Result<(), LndError> {
+        let client = &mut *self.0.lock().await;
+        let client = client.wallet();
+        log::debug!("release_utxos");
+
+        for lease in utxos {
+            let req = tonic_lnd::walletrpc::ReleaseOutputRequest {
+                id: lease.id,
+                // lnd wont accept an OutPoint where both txid_bytes and txid_str are set
+                outpoint: lease.outpoint.map(|o| tonic_lnd::lnrpc::OutPoint {
+                    txid_bytes: o.txid_bytes,
+                    output_index: o.output_index,
+                    ..Default::default()
+                }),
+            };
+            client.release_output(req).await?;
+        }
+        log::debug!("released utxos");
+
+        Ok(())
+    }
+
+    pub async fn broadcast(&self, tx: Transaction) -> Result<bitcoin::Txid, LndError> {
+        let client = &mut *self.0.lock().await;
+        let client = client.wallet();
+
+        let req =
+            tonic_lnd::walletrpc::Transaction { tx_hex: tx.serialize(), ..Default::default() };
+        let res = client.publish_transaction(req).await?;
+        let stream = res.get_ref();
+        if &stream.publish_error != "" {
+            return Err(LndError::Publish(stream.publish_error.to_owned()));
+        }
+        Ok(tx.txid())
+    }
+
     pub async fn required_reserve(
         &self,
         additional_public_channels: u32,
@@ -208,6 +336,8 @@ pub enum LndError {
     UnexpectedUpdate(tonic_lnd::lnrpc::open_status_update::Update),
     ParseVersionFailed { version: String, error: std::num::ParseIntError },
     LNDTooOld(String),
+    BadPsbt(bitcoin::consensus::encode::Error),
+    Publish(String),
 }
 
 impl fmt::Display for LndError {
@@ -229,6 +359,8 @@ impl fmt::Display for LndError {
                 "LND version {} is too old - it would cause GUARANTEED LOSS of sats!",
                 version
             ),
+            LndError::BadPsbt(error) => error.fmt(f),
+            LndError::Publish(error) => error.fmt(f),
         }
     }
 }
@@ -246,6 +378,8 @@ impl std::error::Error for LndError {
             Self::UnexpectedUpdate(_) => None,
             LndError::ParseVersionFailed { version: _, error } => Some(error),
             LndError::LNDTooOld(_) => None,
+            LndError::BadPsbt(error) => Some(error),
+            LndError::Publish(_) => None,
         }
     }
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -6,7 +6,7 @@ use std::{fmt, io};
 use bip78::receiver::{Proposal, UncheckedProposal};
 use bitcoin::consensus::Encodable;
 use bitcoin::psbt::PartiallySignedTransaction;
-use bitcoin::{Address, Amount, Script, TxOut};
+use bitcoin::{Address, Amount, Script, TxOut, Txid};
 use ln_types::P2PAddress;
 use log::{error, info};
 use tonic_lnd::lnrpc::OpenChannelRequest;
@@ -389,7 +389,7 @@ impl Scheduler {
         proposal_psbt.consensus_encode(&mut raw_psbt)?;
         self.lnd.verify_funding(&raw_psbt, temporary_chan_ids).await?;
 
-        // TODO explain why we're doing this superfluous bit or remove it
+        // Remove vestigial invalid signature data from the Original PSBT
         let proposal_psbt =
             PartiallySignedTransaction::from_unsigned_tx(proposal_psbt.unsigned_tx.clone())
                 .expect("resetting tx failed");
@@ -434,6 +434,84 @@ impl Scheduler {
         }
         Ok(())
     }
+
+    /// Send a PayJoin from LND using automatic coin selection and
+    /// automatic fee rate of 2 target confirmations.
+    ///
+    /// `danger_accept_self_signed_uri` should be used for testing only.
+    /// PayJoins are vulnerable to man-in-the-middle attacks, so they must
+    /// communicate over secure connections in production.
+    pub async fn send_payjoin<'a>(
+        &self,
+        uri: bip78::Uri<'_>,
+        danger_accept_self_signed_uri: bool,
+    ) -> Result<Txid, SchedulerError> {
+        log::debug!("get original_psbt");
+        let pj_uri = bip78::UriExt::check_pj_supported(uri)
+            .map_err(|e| SchedulerError::UriDoesNotSupportPayJoin(e.to_string()))?;
+        let (original_psbt, leased_utxos) = if let Some(amount) = pj_uri.amount {
+            log::debug!("funding original_psbt");
+            self.lnd.fund_original_psbt(&pj_uri.address, amount).await?
+        } else {
+            return Err(SchedulerError::UriDoesNotSupportPayJoin(
+                "Missing amount. Make sure the bip21 uri specifies an amount".to_string(),
+            ));
+        };
+
+        log::debug!("sign original_psbt");
+        let original_psbt = self.lnd.sign_psbt(original_psbt).await?;
+        log::debug!("request_payjoin");
+        let res = self.request_payjoin(pj_uri, original_psbt, danger_accept_self_signed_uri).await;
+        if res.is_err() {
+            self.lnd.release_utxos(leased_utxos).await?;
+        } // else, those utxos are now spent and don't need to be released
+        res
+    }
+
+    async fn request_payjoin(
+        &self,
+        pj_uri: bip78::PjUri<'_>,
+        original_psbt: PartiallySignedTransaction,
+        danger_accept_self_signed_uri: bool,
+    ) -> Result<Txid, SchedulerError> {
+        use bip78::PjUriExt;
+
+        let pj_params = bip78::sender::Configuration::non_incentivizing();
+        let saved_inputs = original_psbt.inputs.clone();
+        let (req, ctx) = pj_uri
+            .create_pj_request(original_psbt.clone(), pj_params)
+            .map_err(|_| SchedulerError::Internal("failed to make http pj request"))?;
+
+        let http = reqwest::ClientBuilder::new()
+            .danger_accept_invalid_certs(danger_accept_self_signed_uri)
+            .build()
+            .map_err(|_| SchedulerError::Internal("Failed to build http client"))?;
+
+        let response = http
+            .post(req.url)
+            .header("Content-Type", "text/plain")
+            .body(reqwest::Body::from(req.body))
+            .send()
+            .await
+            .map_err(|_| SchedulerError::Internal("PayJoin http request failed"))?;
+
+        log::debug!("res: {:#?}", &response);
+        let response =
+            response.bytes().await.map_err(|_| SchedulerError::Internal("Bad response"))?;
+
+        let mut payjoin_psbt = ctx
+            .process_response(response.to_vec().as_slice())
+            .map_err(|_| SchedulerError::Internal("bip78::sender ValidationError"))?;
+
+        // fill in utxo info from original_psbt
+        payjoin_psbt.inputs.splice(..saved_inputs.len(), saved_inputs);
+
+        log::debug!("Proposed psbt: {:#?}", &payjoin_psbt);
+        let tx = self.lnd.finalize_psbt(payjoin_psbt).await?;
+        log::debug!("Finalized tx: {:#?}", &tx);
+        let txid = self.lnd.broadcast(tx).await?;
+        Ok(txid)
+    }
 }
 
 pub fn format_bip21(address: Address, amount: Amount, endpoint: url::Url) -> String {
@@ -464,6 +542,8 @@ pub enum SchedulerError {
     PayJoinCannotOpenAnyChannel,
     /// Original Psbt does not respect requested amount
     OriginalPsbtInvalidAmount,
+    /// Bip21 has no valid `pj=` parameter
+    UriDoesNotSupportPayJoin(String),
 }
 
 impl fmt::Display for SchedulerError {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -497,10 +497,10 @@ impl Scheduler {
 
         log::debug!("res: {:#?}", &response);
         let response =
-            response.bytes().await.map_err(|_| SchedulerError::Internal("Bad response"))?;
+            response.text().await.map_err(|_| SchedulerError::Internal("Bad response"))?;
 
         let mut payjoin_psbt = ctx
-            .process_response(response.to_vec().as_slice())
+            .process_response(response.as_bytes())
             .map_err(|_| SchedulerError::Internal("bip78::sender ValidationError"))?;
 
         // fill in utxo info from original_psbt


### PR DESCRIPTION
- [x] send payjoin by giving the scheduler a bip78 uri (builds, integration-tested)

The other tasks can be saved and reviewed in follow up PR(s)

- glue sender to /pj/send http post endpoint
- wire up UI to post a bip21 to the endpoint
- show on-chain balance in UI
