### PR TITLE
Don't panic, handle errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ In other words, your grandmother will be able to somewhat privately open a bunch
 * To work with an *empty* LND wallet you need to use LND 0.14.2
 * Funds in LND or other wallet are not used, so it's not true PayJoin.
 * Invalid request can kill the whole server
-* `.unwraps()`s EVERYWHERE!
 
 ## License
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::path::Path;
 
 use bip78::receiver::*;
 use hyper::service::{make_service_fn, service_fn};
@@ -45,74 +46,78 @@ async fn handle_web_req(
     req: Request<Body>,
     endpoint: url::Url,
 ) -> Result<Response<Body>, hyper::Error> {
-    use std::path::Path;
-
     match (req.method(), req.uri().path()) {
-        (&Method::GET, "/pj") => {
-            let index =
-                std::fs::read(Path::new(STATIC_DIR).join("index.html")).expect("can't open index");
-            Ok(Response::new(Body::from(index)))
-        }
-
-        (&Method::GET, path) if path.starts_with("/pj/static/") => {
-            let directory_traversal_vulnerable_path = &path[("/pj/static/".len())..];
-            let file =
-                std::fs::read(Path::new(STATIC_DIR).join(directory_traversal_vulnerable_path))
-                    .expect("can't open static file");
-            Ok(Response::builder()
-                .status(200)
-                .header("Cache-Control", "max-age=604800")
-                .body(Body::from(file))
-                .expect("valid response"))
-        }
-
-        (&Method::POST, "/pj") => {
-            dbg!(req.uri().query());
-
-            let headers = Headers(req.headers().to_owned());
-            let query = {
-                let uri = req.uri();
-                if let Some(query) = uri.query() {
-                    Some(&query.to_owned());
-                }
-                None
-            };
-            let body = req.into_body();
-            let bytes = hyper::body::to_bytes(body).await?;
-            dbg!(&bytes); // this is correct by my accounts
-            let reader = &*bytes;
-            let original_request = UncheckedProposal::from_request(reader, query, headers).unwrap();
-
-            let proposal_psbt = scheduler.propose_payjoin(original_request).await.unwrap();
-
-            Ok(Response::new(Body::from(proposal_psbt)))
-        }
-
-        (&Method::POST, "/pj/schedule") => {
-            let bytes = hyper::body::to_bytes(req.into_body()).await?;
-            // deserialize x-www-form-urlencoded data with non-strict encoded "channel[arrayindex]"
-            let conf = serde_qs::Config::new(2, false);
-            let request: ScheduledPayJoin =
-                conf.deserialize_bytes(&bytes).expect("invalid request");
-
-            let address = scheduler.schedule_payjoin(&request).await.unwrap();
-            let total_amount = request.total_amount();
-            let uri = scheduler::format_bip21(address.clone(), total_amount, endpoint);
-            let mut response = Response::new(Body::from(uri.clone()));
-            create_qr_code(&uri, &address.to_string());
-            response
-                .headers_mut()
-                .insert(hyper::header::CONTENT_TYPE, "text/plain".parse().unwrap());
-            Ok(response)
-        }
-
-        // Return the 404 Not Found for other routes.
-        _ => {
-            let mut not_found = Response::default();
-            *not_found.status_mut() = StatusCode::NOT_FOUND;
-            Ok(not_found)
-        }
+        (&Method::GET, "/pj") => handle_index().await,
+        (&Method::GET, path) if path.starts_with("/pj/static/") => handle_static(path).await,
+        (&Method::POST, "/pj") => handle_pj(scheduler, req).await,
+        (&Method::POST, "/pj/schedule") => handle_pj_schedule(scheduler, endpoint, req).await,
+        _ => handle_404().await,
     }
+}
+
+async fn handle_404() -> Result<Response<Body>, hyper::Error> {
+    let mut not_found = Response::default();
+    *not_found.status_mut() = StatusCode::NOT_FOUND;
+    Ok(not_found)
+}
+
+async fn handle_index() -> Result<Response<Body>, hyper::Error> {
+    let index = std::fs::read(Path::new(STATIC_DIR).join("index.html")).expect("can't open index");
+    Ok(Response::new(Body::from(index)))
+}
+
+async fn handle_static(path: &str) -> Result<Response<Body>, hyper::Error> {
+    let directory_traversal_vulnerable_path = &path[("/pj/static/".len())..];
+    let file = std::fs::read(Path::new(STATIC_DIR).join(directory_traversal_vulnerable_path))
+        .expect("can't open static file");
+    Ok(Response::builder()
+        .status(200)
+        .header("Cache-Control", "max-age=604800")
+        .body(Body::from(file))
+        .expect("valid response"))
+}
+
+async fn handle_pj(
+    scheduler: Scheduler,
+    req: Request<Body>,
+) -> Result<Response<Body>, hyper::Error> {
+    dbg!(req.uri().query());
+
+    let headers = Headers(req.headers().to_owned());
+    let query = {
+        let uri = req.uri();
+        if let Some(query) = uri.query() {
+            Some(&query.to_owned());
+        }
+        None
+    };
+    let body = req.into_body();
+    let bytes = hyper::body::to_bytes(body).await?;
+    let reader = &*bytes;
+    let original_request = UncheckedProposal::from_request(reader, query, headers).unwrap();
+
+    let proposal_psbt = scheduler.propose_payjoin(original_request).await.unwrap();
+
+    Ok(Response::new(Body::from(proposal_psbt)))
+}
+
+async fn handle_pj_schedule(
+    scheduler: Scheduler,
+    endpoint: url::Url,
+    req: Request<Body>,
+) -> Result<Response<Body>, hyper::Error> {
+    let bytes = hyper::body::to_bytes(req.into_body()).await?;
+    // deserialize x-www-form-urlencoded data with non-strict encoded "channel[arrayindex]"
+    let conf = serde_qs::Config::new(2, false);
+    let request: ScheduledPayJoin = conf.deserialize_bytes(&bytes).expect("invalid request");
+
+    let address = scheduler.schedule_payjoin(&request).await.unwrap();
+    let total_amount = request.total_amount();
+    let uri = scheduler::format_bip21(address.clone(), total_amount, endpoint);
+    let mut response = Response::new(Body::from(uri.clone()));
+    create_qr_code(&uri, &address.to_string());
+    response.headers_mut().insert(hyper::header::CONTENT_TYPE, "text/plain".parse().unwrap());
+    Ok(response)
 }
 
 pub(crate) struct Headers(hyper::HeaderMap);

--- a/src/http.rs
+++ b/src/http.rs
@@ -6,7 +6,7 @@ use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 use qrcode_generator::QrCodeEcc;
 
-use crate::scheduler::{self, ScheduledPayJoin, Scheduler};
+use crate::scheduler::{self, ScheduledPayJoin, Scheduler, SchedulerError};
 
 #[cfg(not(feature = "test_paths"))]
 const STATIC_DIR: &str = "/usr/share/nolooking/static";
@@ -46,41 +46,44 @@ async fn handle_web_req(
     req: Request<Body>,
     endpoint: url::Url,
 ) -> Result<Response<Body>, hyper::Error> {
-    match (req.method(), req.uri().path()) {
+    let result = match (req.method(), req.uri().path()) {
         (&Method::GET, "/pj") => handle_index().await,
         (&Method::GET, path) if path.starts_with("/pj/static/") => handle_static(path).await,
         (&Method::POST, "/pj") => handle_pj(scheduler, req).await,
         (&Method::POST, "/pj/schedule") => handle_pj_schedule(scheduler, endpoint, req).await,
         _ => handle_404().await,
+    };
+
+    match result {
+        Ok(resp) => Ok(resp),
+        Err(err) => err.into_response(),
     }
 }
 
-async fn handle_404() -> Result<Response<Body>, hyper::Error> {
+async fn handle_404() -> Result<Response<Body>, HttpError> {
     let mut not_found = Response::default();
     *not_found.status_mut() = StatusCode::NOT_FOUND;
     Ok(not_found)
 }
 
-async fn handle_index() -> Result<Response<Body>, hyper::Error> {
+async fn handle_index() -> Result<Response<Body>, HttpError> {
     let index = std::fs::read(Path::new(STATIC_DIR).join("index.html")).expect("can't open index");
     Ok(Response::new(Body::from(index)))
 }
 
-async fn handle_static(path: &str) -> Result<Response<Body>, hyper::Error> {
+async fn handle_static(path: &str) -> Result<Response<Body>, HttpError> {
     let directory_traversal_vulnerable_path = &path[("/pj/static/".len())..];
-    let file = std::fs::read(Path::new(STATIC_DIR).join(directory_traversal_vulnerable_path))
-        .expect("can't open static file");
-    Ok(Response::builder()
-        .status(200)
-        .header("Cache-Control", "max-age=604800")
-        .body(Body::from(file))
-        .expect("valid response"))
+    match std::fs::read(Path::new(STATIC_DIR).join(directory_traversal_vulnerable_path)) {
+        Ok(file) => Response::builder()
+            .status(200)
+            .header("Cache-Control", "max-age=604800")
+            .body(Body::from(file))
+            .map_err(HttpError::Http),
+        Err(_) => handle_404().await,
+    }
 }
 
-async fn handle_pj(
-    scheduler: Scheduler,
-    req: Request<Body>,
-) -> Result<Response<Body>, hyper::Error> {
+async fn handle_pj(scheduler: Scheduler, req: Request<Body>) -> Result<Response<Body>, HttpError> {
     dbg!(req.uri().query());
 
     let headers = Headers(req.headers().to_owned());
@@ -94,9 +97,9 @@ async fn handle_pj(
     let body = req.into_body();
     let bytes = hyper::body::to_bytes(body).await?;
     let reader = &*bytes;
-    let original_request = UncheckedProposal::from_request(reader, query, headers).unwrap();
+    let original_request = UncheckedProposal::from_request(reader, query, headers)?;
 
-    let proposal_psbt = scheduler.propose_payjoin(original_request).await.unwrap();
+    let proposal_psbt = scheduler.propose_payjoin(original_request).await?;
 
     Ok(Response::new(Body::from(proposal_psbt)))
 }
@@ -105,22 +108,88 @@ async fn handle_pj_schedule(
     scheduler: Scheduler,
     endpoint: url::Url,
     req: Request<Body>,
-) -> Result<Response<Body>, hyper::Error> {
+) -> Result<Response<Body>, HttpError> {
     let bytes = hyper::body::to_bytes(req.into_body()).await?;
     // deserialize x-www-form-urlencoded data with non-strict encoded "channel[arrayindex]"
     let conf = serde_qs::Config::new(2, false);
-    let request: ScheduledPayJoin = conf.deserialize_bytes(&bytes).expect("invalid request");
+    let request: ScheduledPayJoin = conf.deserialize_bytes(&bytes)?;
 
-    let address = scheduler.schedule_payjoin(&request).await.unwrap();
+    let address = scheduler.schedule_payjoin(&request).await?;
     let total_amount = request.total_amount();
     let uri = scheduler::format_bip21(address.clone(), total_amount, endpoint);
     let mut response = Response::new(Body::from(uri.clone()));
     create_qr_code(&uri, &address.to_string());
-    response.headers_mut().insert(hyper::header::CONTENT_TYPE, "text/plain".parse().unwrap());
+    response.headers_mut().insert(hyper::header::CONTENT_TYPE, "text/plain".parse()?);
     Ok(response)
 }
 
 pub(crate) struct Headers(hyper::HeaderMap);
 impl bip78::receiver::Headers for Headers {
     fn get_header(&self, key: &str) -> Option<&str> { self.0.get(key)?.to_str().ok() }
+}
+
+#[derive(Debug)]
+pub enum HttpError {
+    Bip78Request(bip78::receiver::RequestError),
+    Hyper(hyper::Error),
+    Http(hyper::http::Error),
+    InvalidHeaderValue(hyper::header::InvalidHeaderValue),
+    Scheduler(SchedulerError),
+    Serde(serde_qs::Error),
+}
+
+impl HttpError {
+    /// Transforms an [HttpError] into a HTTP response
+    pub fn into_response(self) -> Result<Response<Body>, hyper::Error> {
+        if let Self::Hyper(err) = self {
+            return Err(err);
+        }
+
+        let resp = Response::new(Body::from(self.to_string()));
+        let (mut parts, body) = resp.into_parts();
+
+        // TODO respond with well known errors as defined in BIP-0078
+        // https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki#receivers-well-known-errors
+        parts.status = match self {
+            Self::Bip78Request(_)
+            | Self::Hyper(_)
+            | Self::Http(_)
+            | Self::InvalidHeaderValue(_)
+            | Self::Scheduler(_)
+            | Self::Serde(_) => StatusCode::BAD_REQUEST,
+        };
+
+        // TODO: Avoid writing error directly to HTTP response (bad security if public facing)
+        // instead respond with the same format as well known errors
+        Ok(Response::from_parts(parts, body))
+    }
+}
+
+impl std::fmt::Display for HttpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // TODO: Have proper error printing
+        write!(f, "api: {:?}", self)
+    }
+}
+
+impl std::error::Error for HttpError {}
+
+impl From<bip78::receiver::RequestError> for HttpError {
+    fn from(e: bip78::receiver::RequestError) -> Self { Self::Bip78Request(e) }
+}
+
+impl From<hyper::Error> for HttpError {
+    fn from(e: hyper::Error) -> Self { Self::Hyper(e) }
+}
+
+impl From<hyper::header::InvalidHeaderValue> for HttpError {
+    fn from(e: hyper::header::InvalidHeaderValue) -> Self { Self::InvalidHeaderValue(e) }
+}
+
+impl From<SchedulerError> for HttpError {
+    fn from(e: SchedulerError) -> Self { Self::Scheduler(e) }
+}
+
+impl From<serde_qs::Error> for HttpError {
+    fn from(e: serde_qs::Error) -> Self { Self::Serde(e) }
 }


### PR DESCRIPTION
Fix "`unwrap()`s everywhere" disclaimer by handling errors. They still need to propagate to the UI.

HttpErrors still need to be returned with proper HTTP status codes

There are still 2 unwraps on mutex locks `let mut pj_by_spk = self.pjs.lock().unwrap();` which should probably panic with `expect` instead. What do you think?

I also need to add @evanlinjin as co-author of the HttpError. Work from #10 finally making it in!

fix #33

#50 *could* be fixed in this PR by pushing an update to the front end. but this at least responds by passing the error to the sender where they should end up in logs