### PR TITLE
Fix schedule POST deserialization

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,6 +30,7 @@
 				x-flex direction="column">
 				<fieldset>
 					<legend>Queue Channels to Open</legend>
+					<br>
 					<!-- channels -->
 					<x-grid columns=2 id="channels">
 						<label id="destinationLabel" span=1>Destination Node</label><label id="capacityLabel" span=1>Channel Capacity (sats)</label>

--- a/src/http.rs
+++ b/src/http.rs
@@ -106,7 +106,7 @@ async fn handle_schedule(
 ) -> Result<Response<Body>, HttpError> {
     let bytes = hyper::body::to_bytes(req.into_body()).await?;
     // deserialize x-www-form-urlencoded data with non-strict encoded "channel[arrayindex]"
-    let conf = serde_qs::Config::new(2, false);
+    let conf = serde_qs::Config::new(5, false); // 5 is default max_depth
     let request: ChannelBatch = conf.deserialize_bytes(&bytes)?;
 
     let (uri, address) = scheduler.schedule_payjoin(request).await?;


### PR DESCRIPTION
Reordering the form causes a deserialization error on
```
let request: ChannelBatch = conf.deserialize_bytes(&bytes)?;
```
Not sure what is enforcing the error but let's just leave in this order for now