### PR TITLE
Test lsp integration

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -19,14 +19,15 @@ pub struct Quote {
 pub async fn request_quote(
     p2p_address: &P2PAddress,
     refund_address: &Address,
+    lsp_endpoint: &String,
 ) -> Result<Quote, LspError> {
     let https = hyper_tls::HttpsConnector::new();
     let client = Client::builder().build::<_, hyper::Body>(https);
     // get address
     // suggest capacity
     let base_uri = format!(
-        "https://nolooking.chaincase.app/api/request-inbound?nodeid={}&capacity={}&duration={}&refund_address={}",
-        p2p_address, 1000000, 1, refund_address
+        "{}/request-inbound?nodeid={}&capacity={}&duration={}&refund_address={}",
+        lsp_endpoint, p2p_address, 1000000, 1, refund_address
     ); // TODO confirm p2p_address is urlencoded
     let url: Uri = base_uri.parse().map_err(InternalLspError::Uri)?;
     let req =


### PR DESCRIPTION
On second thought, the from_config might not be what enables integration testing. Making LspClient a trait with an alternative request_quote() might be. I would still want lsp_endpoint encapsulated from scheduler, either by removing the configuration or parsing it into a struct a from_config method.

- [ ] Mock LspClient as Trait Lsp that implements 
- [ ] configure LspClient::from_config
