### PR TITLE
Feature vendored OpenSSL for static builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,6 +947,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.24.0+1.1.1s"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3498f259dab01178c6228c6b00dcef0ed2a2d5e20d648c017861227773ea4abd"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,6 +964,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ spec = "config_spec.toml"
 
 [features]
 test_paths = []
+#  If enabled, the crate will compile and statically link to a vendored copy of OpenSSL. This feature has no effect on Windows and macOS, where OpenSSL is not used.
+vendored = ["hyper-tls/vendored"]
 
 [dependencies]
 bitcoin = { version = "0.28.1", features = ["use-serde"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN echo "Preparing to cargo build for x86_64 (${TARGETARCH})"
 RUN apt-get update && apt-get install -y musl-tools musl-dev
 # Add our x86 target to rust, then compile and install
 RUN rustup target add x86_64-unknown-linux-musl
-RUN cargo --config "net.git-fetch-with-cli=true" install --target x86_64-unknown-linux-musl --path .
+RUN cargo --config "net.git-fetch-with-cli=true" install -F vendored  --target x86_64-unknown-linux-musl --path .
 
 # ARM
 FROM builder AS branch-version-arm64
@@ -40,7 +40,7 @@ RUN rustup target add aarch64-unknown-linux-musl
 ENV CC_aarch64_unknown_linux_musl=clang
 ENV AR_aarch64_unknown_linux_musl=llvm-ar
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"
-RUN cargo --config "net.git-fetch-with-cli=true" install --target aarch64-unknown-linux-musl --path .
+RUN cargo --config "net.git-fetch-with-cli=true" install -F vendored --target aarch64-unknown-linux-musl --path .
 
 # We build for either x86_64 or ARM from above options using the docker $TARGETARCH
 FROM branch-version-${TARGETARCH} AS chosen_builder


### PR DESCRIPTION
Otherwise docker buildx fails