### PR TITLE
Rename feature prod_public_path and default to local

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 spec = "config_spec.toml"
 
 [features]
-test_paths = []
+prod_public_path = []
 
 [dependencies]
 bitcoin = { version = "0.28.1", features = ["use-serde"] }

--- a/src/http.rs
+++ b/src/http.rs
@@ -10,10 +10,10 @@ use qrcode_generator::QrCodeEcc;
 use crate::lsp::Quote;
 use crate::scheduler::{ChannelBatch, Scheduler, SchedulerError};
 
-#[cfg(not(feature = "test_paths"))]
+#[cfg(feature = "prod_public_path")]
 const PUBLIC_DIR: &str = "/usr/share/nolooking/public";
 
-#[cfg(feature = "test_paths")]
+#[cfg(not(feature = "prod_public_path"))]
 const PUBLIC_DIR: &str = "public";
 
 /// Create QR code and save to `PUBLIC_DIR/qr_codes/<name>.png`


### PR DESCRIPTION
readme instructions currently do not work (we don't suggest using feature) as the `/usr/share/` one is the default.

In the future this should be made into a config arg